### PR TITLE
feat(alert-rules): provide alert rules examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ROB-COS-configurations
-Set of configurations examples for ROB COS
+
+Set of configurations examples for ROB COS.
 
 ## Configurations
 - [Grafana agent](./grafana-agent/grafana-agent.md) -- Configurations for the Grafana agent snap.
 - [Grafana dashboards](./grafana-dashboards/grafana-dashboards.md) -- Dashboards to monitor devices.
 - [Foxglove layouts](./foxglove-layouts/foxglove-layouts.md) -- Layouts to visualize robotics data.
+- [Alert rules](./alert-rules/readme.md) -- Alert rules for the different applications.

--- a/alert-rules/loki/high_log_rate.rules
+++ b/alert-rules/loki/high_log_rate.rules
@@ -1,0 +1,11 @@
+groups:
+  - name: high_log_rate
+  rules:
+  - alert: HighLogRate
+      expr: 'sum(rate({job="loki.source.journal.read"}[5m])) by (instance) > 100'
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High log rate detected for {{ $labels.instance }}"
+        description: "The log rate for {{ $labels.instance }} has exceeded 100 logs per second for the last 5 minutes."

--- a/alert-rules/prometheus/low_memory.rules
+++ b/alert-rules/prometheus/low_memory.rules
@@ -1,0 +1,21 @@
+groups:
+  - name: robot-2-low-memory
+    rules:
+    - alert: Robot2LowMemory
+      annotations:
+        description: "Low memory alert specific to robot-2"
+        summary: "Robot {{ $labels.instance }} has less than 1 GB of memory free."
+      expr: (node_memory_MemFree_bytes{device_instance="robot-2"})/1e9 < 1
+      for: 5m
+      labels:
+        severity: critical
+  - name: low-memory
+    rules:
+    - alert: LowMemory
+      annotations:
+        description: "Generic low memory alert"
+        summary: "Robot {{ $labels.instance }} has less than 1 GB of memory free."
+      expr: (node_memory_MemFree_bytes{})/1e9 < 1
+      for: 5m
+      labels:
+        severity: critical

--- a/alert-rules/prometheus/ros2_battery.rules
+++ b/alert-rules/prometheus/ros2_battery.rules
@@ -1,0 +1,11 @@
+groups:
+  - name: low-battery
+    rules:
+    - alert: LowBattery
+      annotations:
+        description: "Generic low battery alert"
+        summary: "Robot {{ $labels.instance }} has less than 10 % of battery."
+      expr: (my_battery__{})/1e9 < 10
+      for: 5m
+      labels:
+        severity: warning

--- a/alert-rules/readme.md
+++ b/alert-rules/readme.md
@@ -1,0 +1,21 @@
+# Alert rules
+This folder contains alert rules for different applications.
+
+The alert rules must be passed to the approriate application.
+
+## Rules
+
+### Prometheus
+
+- [low_memory.rules](./prometheus/low_memory.rules) -- This rules file contains two
+rules. One for low memory alert specific to robot-2 and a generic rule for low memory for all the devices.
+- [ros2_battery](./prometheus/ros2_battery.rules) -- This rule triggers when the ROS 2 topic `/battery_level` from a robot is below 10%. This is meant to work with the [ros2-grafana-agent](https://github.com/canonical/ros2-grafana-agent-example) example.
+
+You can find more about Prometheus alert rules in the [official documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+
+### Loki
+
+- [high_log_rate.rules](./loki/high_log_rate.rules) -- This rule triggers when the log
+rate for an instance has exceeded 100 logs per second for the last 5 minutes.
+
+You can find more about Loki alert rules in the [official documentation](https://grafana.com/docs/loki/latest/alert/).


### PR DESCRIPTION
Provide alert rules examples.

Alerts highly depends on the devices and their applications.

Some alerts can be generic and some can be device specific.

Here we are only talking about the alert rules for devices, since alert rules for JuJu apps are already covered by COS documentation.