### PR TITLE
fix(grafana-logs): showTime and wrapLogMessage for clarity

### DIFF
--- a/grafana-dashboards/systemd-and-snaps-logs.json
+++ b/grafana-dashboards/systemd-and-snaps-logs.json
@@ -145,9 +145,9 @@
           "prettifyLogMessage": false,
           "showCommonLabels": false,
           "showLabels": false,
-          "showTime": false,
+          "showTime": true,
           "sortOrder": "Descending",
-          "wrapLogMessage": false
+          "wrapLogMessage": true
         },
         "targets": [
           {
@@ -194,7 +194,7 @@
               "showLabels": false,
               "showTime": true,
               "sortOrder": "Descending",
-              "wrapLogMessage": false
+              "wrapLogMessage": true
             },
             "targets": [
               {


### PR DESCRIPTION
Husarion pointed that the Timestamp was not showing for the snap logs.
I also enabled the wrapLogMessage so it less painful to browse the logs.

Before:
![image](https://github.com/user-attachments/assets/3a30e744-de40-4722-8fea-cecdaf0440b4)
After:
![image](https://github.com/user-attachments/assets/e1bc5362-a015-44c3-abf9-b31139d6273b)
